### PR TITLE
Handle unavailable battery UI

### DIFF
--- a/src/ui/cuicui/application-ui/battery/battery-indicator/battery-indicator.tsx
+++ b/src/ui/cuicui/application-ui/battery/battery-indicator/battery-indicator.tsx
@@ -64,7 +64,7 @@ export const BatteryIndicator: React.FC<BatteryInfoProps> = ({
       {getBatteryIcon(level, isCharging)}
       <div className="flex flex-col">
         <span className={`text-sm font-medium ${getTextColor(level)}`}>
-          {level !== null ? `${Math.round(level)}%` /* Round the battery level */ : 'Unavailable'}
+          {level ? `${Math.round(level)}%` /* Round the battery level */ : 'Unavailable'}
         </span>
         <span className="text-xs text-neutral-500 flex items-center">
           {isCharging ? (

--- a/src/ui/cuicui/application-ui/battery/battery-indicator/battery-indicator.tsx
+++ b/src/ui/cuicui/application-ui/battery/battery-indicator/battery-indicator.tsx
@@ -25,7 +25,7 @@ export const BatteryIndicator: React.FC<BatteryInfoProps> = ({
   dischargingTime,
   className,
 }) => {
-  const batteryLevel = level ?? 0;
+  const batteryLevel = Math.round(level) ?? 0;
 
   const getBatteryIcon = (level: number, isCharging: boolean | null) => {
     if (isCharging)

--- a/src/ui/cuicui/application-ui/battery/battery-indicator/battery-indicator.tsx
+++ b/src/ui/cuicui/application-ui/battery/battery-indicator/battery-indicator.tsx
@@ -65,7 +65,7 @@ export const BatteryIndicator: React.FC<BatteryInfoProps> = ({
       {getBatteryIcon(level, isCharging)}
       <div className="flex flex-col">
         <span className={`text-sm font-medium ${getTextColor(level)}`}>
-          {level !== null ? `${batteryLevel}%` : 'Unavailable' /* Mayby add question mark ?  */}
+          {level !== null ? `${batteryLevel}%` : 'Unavailable'}
         </span>
         <span className="text-xs text-neutral-500 flex items-center">
           {isCharging ? (

--- a/src/ui/cuicui/application-ui/battery/battery-indicator/battery-indicator.tsx
+++ b/src/ui/cuicui/application-ui/battery/battery-indicator/battery-indicator.tsx
@@ -25,7 +25,6 @@ export const BatteryIndicator: React.FC<BatteryInfoProps> = ({
   dischargingTime,
   className,
 }) => {
-  const batteryLevel = Math.round(level ?? 0); // Round the battery level
 
   const getBatteryIcon = (level: number | null, isCharging: boolean | null) => {
     if (level === null) return <Battery className="w-5 h-5 text-orange-500" />;
@@ -65,7 +64,7 @@ export const BatteryIndicator: React.FC<BatteryInfoProps> = ({
       {getBatteryIcon(level, isCharging)}
       <div className="flex flex-col">
         <span className={`text-sm font-medium ${getTextColor(level)}`}>
-          {level !== null ? `${batteryLevel}%` : 'Unavailable'}
+          {level !== null ? `${Math.round(level)}%` /* Round the battery level */ : 'Unavailable'}
         </span>
         <span className="text-xs text-neutral-500 flex items-center">
           {isCharging ? (

--- a/src/ui/cuicui/application-ui/battery/battery-indicator/battery-indicator.tsx
+++ b/src/ui/cuicui/application-ui/battery/battery-indicator/battery-indicator.tsx
@@ -25,9 +25,10 @@ export const BatteryIndicator: React.FC<BatteryInfoProps> = ({
   dischargingTime,
   className,
 }) => {
-  const batteryLevel = Math.round(level) ?? 0;
+  const batteryLevel = Math.round(level ?? 0); // Round the battery level
 
-  const getBatteryIcon = (level: number, isCharging: boolean | null) => {
+  const getBatteryIcon = (level: number | null, isCharging: boolean | null) => {
+    if (level === null) return <Battery className="w-5 h-5 text-orange-500" />;
     if (isCharging)
       return <BatteryCharging className="w-5 h-5 text-blue-500" />;
     if (level >= 90)
@@ -37,7 +38,8 @@ export const BatteryIndicator: React.FC<BatteryInfoProps> = ({
     return <BatteryWarning className="w-5 h-5 text-red-500" />;
   };
 
-  const getTextColor = (level: number) => {
+  const getTextColor = (level: number | null) => {
+    if (level === null) return "text-orange-500";
     if (level >= 50) return "text-emerald-500";
     if (level >= 20) return "text-yellow-500";
     return "text-red-500";
@@ -60,10 +62,10 @@ export const BatteryIndicator: React.FC<BatteryInfoProps> = ({
         className,
       )}
     >
-      {getBatteryIcon(batteryLevel, isCharging)}
+      {getBatteryIcon(level, isCharging)}
       <div className="flex flex-col">
-        <span className={`text-sm font-medium ${getTextColor(batteryLevel)}`}>
-          {batteryLevel}%
+        <span className={`text-sm font-medium ${getTextColor(level)}`}>
+          {level !== null ? `${batteryLevel}%` : 'Unavailable' /* Mayby add question mark ?  */}
         </span>
         <span className="text-xs text-neutral-500 flex items-center">
           {isCharging ? (

--- a/src/ui/cuicui/hooks/use-battery/hook/preview-use-battery.tsx
+++ b/src/ui/cuicui/hooks/use-battery/hook/preview-use-battery.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { BatteryIndicator } from "#/src/ui/cuicui/application-ui/battery/battery-indicator/battery-indicator";
-import { ThreeDotSimpleLoader } from "#/src/ui/cuicui/common-ui/loaders/three-dot-simple-loader/three-dot-simple-loader";
+import { ThreeDotSimpleLoader } from "#/src/ui/cuicui/common-ui/loaders/three-dot-simple-loader/three-dot-simple-loader"; // Unrequired
 import { useBattery } from "#/src/ui/cuicui/hooks/use-battery/hook/use-battery";
 
 export const PreviewUseBattery = () => {

--- a/src/ui/cuicui/hooks/use-battery/hook/preview-use-battery.tsx
+++ b/src/ui/cuicui/hooks/use-battery/hook/preview-use-battery.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { BatteryIndicator } from "#/src/ui/cuicui/application-ui/battery/battery-indicator/battery-indicator";
-import { ThreeDotSimpleLoader } from "#/src/ui/cuicui/common-ui/loaders/three-dot-simple-loader/three-dot-simple-loader"; // Unrequired
+import { ThreeDotSimpleLoader } from "#/src/ui/cuicui/common-ui/loaders/three-dot-simple-loader/three-dot-simple-loader"; // Allows to wait for the battery information to load
 import { useBattery } from "#/src/ui/cuicui/hooks/use-battery/hook/use-battery";
 
 export const PreviewUseBattery = () => {


### PR DESCRIPTION
# Pull Request

## Description

If the user is using a browser that does not provide the battery level, the battery is no longer at 0 but displays 'Unavailable' in orange.

<img width="342" alt="Screenshot 2024-09-17 at 18 50 13" src="https://github.com/user-attachments/assets/5c08695a-7709-4bef-9087-c8fd47ace4ea">

Safari screenshot

Additionally, I have added rounding to the battery percentage to avoid decimal numbers.

## Type of Change

Please delete options that are not relevant:

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

Please ensure your PR fulfills the following requirements:

- [X] I have read and followed the [Contributing Guidelines](https://github.com/cuicui-project/contributing).
- [X] My code follows the code style of this project.
- [X] My code respect as much as possible the W3C standards with corresponding ARIA roles and html semantics.
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works. -->
<!-- - [ ] New and existing unit tests pass locally with my changes. -->
- [X] I have performed a self-review of my code.
- [X] I have commented my code (if necessary), particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation (if applicable).
- [X] My changes generate no new warnings.

## Screenshots (if applicable)

If your PR includes UI changes, please include screenshots or GIFs showing the new behavior.

Browser : Safari
<img width="342" alt="Screenshot 2024-09-17 at 18 55 30" src="https://github.com/user-attachments/assets/5b9a7be3-2a2f-4921-b80d-ddfc8f089611">

Browser : Chrome
<img width="342" alt="Screenshot 2024-09-17 at 18 56 36" src="https://github.com/user-attachments/assets/c0fdef74-dc42-4b30-8cc3-3ba62d79449c">