### PR TITLE
Use click outside & noise & border trail & grid pattern

### DIFF
--- a/src/ui/cuicui/hooks/hooks.section.tsx
+++ b/src/ui/cuicui/hooks/hooks.section.tsx
@@ -30,6 +30,7 @@ import { useStopwatchCategory } from "#/src/ui/cuicui/hooks/use-stopwatch/catego
 import { useFirstVisitCategory } from "#/src/ui/cuicui/hooks/use-first-visit/category.use-first-visit";
 import { useRerenderCategory } from "#/src/ui/cuicui/hooks/use-rerender/component.use-rerender";
 import { useMeasureCategory } from "#/src/ui/cuicui/hooks/use-measure/category.use-measure";
+import { useClickOutsideCategory } from "#/src/ui/cuicui/hooks/use-click-outside/category.use-click-outside";
 
 export const hooksSection: SectionType = {
   type: "single-component",
@@ -39,6 +40,7 @@ export const hooksSection: SectionType = {
   icon: ToyBrickIcon,
   categoriesList: [
     useBatteryCategory,
+    useClickOutsideCategory,
     useCopyToClipboardCategory,
     useCounterCategory,
     useDebounceCategory,

--- a/src/ui/cuicui/hooks/use-click-outside/category.use-click-outside.tsx
+++ b/src/ui/cuicui/hooks/use-click-outside/category.use-click-outside.tsx
@@ -1,0 +1,29 @@
+import { MapIcon } from "lucide-react";
+import type { SingleComponentCategoryType } from "#/src/lib/types/component";
+import PreviewUseClickOutside from "#/src/ui/cuicui/hooks/use-click-outside/preview.use-click-outside";
+
+export const useClickOutsideCategory: SingleComponentCategoryType = {
+  slug: "use-click-outside",
+  name: "Use Click Outside",
+  description:
+    "A React hook that allows you to detect clicks outside of a specified element.",
+  releaseDateCategory: new Date("2024-10-15"),
+  icon: MapIcon,
+  previewCategory: {
+    component: <PreviewUseClickOutside />,
+    previewScale: 0.8,
+  },
+  component: {
+    lastUpdatedDateComponent: new Date("2024-10-15"),
+    sizePreview: "xl",
+    isIframed: false,
+    variantList: [
+      {
+        name: "Default",
+        component: <PreviewUseClickOutside />,
+        slugComponentFile: "use-click-outside",
+        slugPreviewFile: "preview.use-click-outside",
+      },
+    ],
+  },
+};

--- a/src/ui/cuicui/hooks/use-click-outside/preview.use-click-outside.tsx
+++ b/src/ui/cuicui/hooks/use-click-outside/preview.use-click-outside.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { useOnClickOutside } from "#/src/ui/cuicui/hooks/use-click-outside/use-click-outside";
+import { useRef } from "react";
+import { toast } from "sonner";
+
+export default function PreviewUseClickOutside() {
+  const ref = useRef(null);
+
+  const handleClickOutside = () => {
+    // Your custom logic here
+    toast("clicked outside");
+  };
+
+  const handleClickInside = () => {
+    // Your custom logic here
+    toast("clicked inside");
+  };
+
+  useOnClickOutside(ref, handleClickOutside);
+
+  return (
+    <button
+      type="button"
+      className="size-72  bg-neutral-500/10 rounded-xl border border-neutral-400/10"
+      ref={ref}
+      onClick={handleClickInside}
+    >
+      Click me
+    </button>
+  );
+}

--- a/src/ui/cuicui/hooks/use-click-outside/use-click-outside.ts
+++ b/src/ui/cuicui/hooks/use-click-outside/use-click-outside.ts
@@ -1,0 +1,42 @@
+"use client";
+import { useEventListener } from "#/src/ui/cuicui/hooks/use-event-listener/use-event-listener";
+import type { RefObject } from "react";
+
+type EventType =
+  | "mousedown"
+  | "mouseup"
+  | "touchstart"
+  | "touchend"
+  | "focusin"
+  | "focusout";
+
+export function useOnClickOutside<T extends HTMLElement = HTMLElement>(
+  ref: RefObject<T> | RefObject<T>[],
+  handler: (event: MouseEvent | TouchEvent | FocusEvent) => void,
+  eventType: EventType = "mousedown",
+  eventListenerOptions: AddEventListenerOptions = {},
+): void {
+  useEventListener(
+    eventType,
+    (event) => {
+      const target = event.target as Node;
+
+      // Do nothing if the target is not connected element with document
+      if (!target?.isConnected) {
+        return;
+      }
+
+      const isOutside = Array.isArray(ref)
+        ? ref
+            .filter((r) => Boolean(r.current))
+            .every((r) => r.current && !r.current.contains(target))
+        : ref.current && !ref.current.contains(target);
+
+      if (isOutside) {
+        handler(event);
+      }
+    },
+    undefined,
+    eventListenerOptions,
+  );
+}

--- a/src/ui/cuicui/other/creative-effects/animated-noise/animated-noise.tsx
+++ b/src/ui/cuicui/other/creative-effects/animated-noise/animated-noise.tsx
@@ -1,0 +1,69 @@
+import { cn } from "#/src/utils/cn";
+import type { HTMLAttributes } from "react";
+
+export default function AnimatedNoise({
+  opacity,
+  className,
+  ...props
+}: { opacity: number } & HTMLAttributes<HTMLDivElement>) {
+  return (
+    <>
+      <style>{style}</style>
+      <div
+        className={cn(
+          "absolute bg-noise inset-0 z-40 pointer-events-none select-none",
+          className,
+        )}
+        style={{
+          animation: "noise .8s steps(10) infinite",
+          backgroundRepeat: "repeat",
+          backgroundImage: svgUrlEncoded,
+          backgroundSize: "20%",
+          opacity,
+        }}
+        {...props}
+      />
+    </>
+  );
+}
+
+const svgUrlEncoded = `url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' version='1.1' xmlnsXlink='http://www.w3.org/1999/xlink' viewBox='0 0 700 700' width='700' height='700' opacity='1'%3e%3ctitle%3enoise%3c/title%3e%3cdefs%3e%3cfilter id='nnnoise-filter' x='-20%25' y='-20%25' width='140%25' height='140%25' filterUnits='objectBoundingBox' primitiveUnits='userSpaceOnUse' color-interpolation-filters='linearRGB'%3e%3cfeTurbulence type='fractalNoise' baseFrequency='0.2' numOctaves='4' seed='15' stitchTiles='stitch' x='0%25' y='0%25' width='100%25' height='100%25' result='turbulence'/%3e%3cfeSpecularLighting surfaceScale='5' specularConstant='0.8' specularExponent='20' lighting-color='white' x='0%25' y='0%25' width='100%25' height='100%25' in='turbulence' result='specularLighting'%3e%3cfeDistantLight azimuth='3' elevation='96'/%3e%3c/feSpecularLighting%3e%3cfeColorMatrix type='saturate' values='0' x='0%25' y='0%25' width='100%25' height='100%25' in='specularLighting' result='colormatrix'/%3e%3c/filter%3e%3c/defs%3e%3crect width='700' height='700' fill='black'/%3e%3crect width='700' height='700' fill='white' filter='url(%23nnnoise-filter)'/%3e%3c/svg%3e")`;
+
+const style = `
+@keyframes noise {
+  0%, 100% {
+    scale: 2;
+    transform: translate(0, 0);
+  }
+  1%, 9% {
+    transform: translate(0px, 0px);
+  }
+  10%, 20% {
+    transform: translate(10px, -20px);
+  }
+  21%, 30% {
+    transform: translate(-15px, 25px);
+  }
+  31%, 40% {
+    transform: translate(20px, -30px);
+  }
+  41%, 50% {
+    transform: translate(-25px, 35px);
+  }
+  51%, 60% {
+    transform: translate(30px, -40px);
+  }
+  61%, 70% {
+    transform: translate(-35px, 45px);
+  }
+  71%, 80% {
+    transform: translate(40px, -50px);
+  }
+  81%, 90% {
+    transform: translate(-45px, 55px);
+  }
+  91%, 99% {
+    transform: translate(50px, -60px);
+  }
+}
+  `;

--- a/src/ui/cuicui/other/creative-effects/animated-noise/component.animated-noise.tsx
+++ b/src/ui/cuicui/other/creative-effects/animated-noise/component.animated-noise.tsx
@@ -1,0 +1,26 @@
+import type { ComponentType } from "#/src/lib/types/component";
+import PreviewAnimatedNoise from "#/src/ui/cuicui/other/creative-effects/animated-noise/preview.animated-noise";
+import PreviewStaticNoise from "#/src/ui/cuicui/other/creative-effects/animated-noise/preview.static-noise";
+
+export const animatedNoiseComponent: ComponentType = {
+  slug: "animated-noise",
+  name: "Animated Noise",
+  description:
+    "A noise effect that can be used in any project with any artisitic style",
+  sizePreview: "lg",
+  variantList: [
+    {
+      name: "Animated Noise",
+      slugPreviewFile: "preview.animated-noise",
+      slugComponentFile: "animated-noise",
+      component: <PreviewAnimatedNoise />,
+    },
+    {
+      name: "Static Noise",
+      slugPreviewFile: "preview.static-noise",
+      slugComponentFile: "static-noise",
+      component: <PreviewStaticNoise />,
+    },
+  ],
+  lastUpdatedDateComponent: new Date("2024-10-14"),
+};

--- a/src/ui/cuicui/other/creative-effects/animated-noise/preview.animated-noise.tsx
+++ b/src/ui/cuicui/other/creative-effects/animated-noise/preview.animated-noise.tsx
@@ -1,0 +1,16 @@
+import AnimatedNoise from "#/src/ui/cuicui/other/creative-effects/animated-noise/animated-noise";
+import GridPattern from "#/src/ui/cuicui/other/patterns/grid-pattern/grid-pattern";
+
+export default function PreviewAnimatedNoise() {
+  return (
+    <div className="relative h-full w-full">
+      <AnimatedNoise opacity={0.1} />
+      <section className="font-semibold h-full w-full  bg-gradient-to-t dark:to-gray-800 dark:from-gray-950 to-gray-50 from-white flex flex-col items-center justify-center dark:text-white text-black">
+        <GridPattern />
+        <p className="text-4xl px-8 font-semibold text-center tracking-tight">
+          Animated noise effect with svg only
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/ui/cuicui/other/creative-effects/animated-noise/preview.static-noise.tsx
+++ b/src/ui/cuicui/other/creative-effects/animated-noise/preview.static-noise.tsx
@@ -1,0 +1,16 @@
+import StaticNoise from "#/src/ui/cuicui/other/creative-effects/animated-noise/static-noise";
+import GridPattern from "#/src/ui/cuicui/other/patterns/grid-pattern/grid-pattern";
+
+export default function PreviewStaticNoise() {
+  return (
+    <div className="relative h-full w-full">
+      <StaticNoise opacity={0.1} />
+      <section className="font-semibold h-full w-full  bg-gradient-to-t dark:to-gray-800 dark:from-gray-950 to-gray-50 from-white flex flex-col items-center justify-center dark:text-white text-black">
+        <GridPattern />
+        <p className="text-4xl px-8 font-semibold text-center tracking-tight">
+          Animated noise effect with svg only
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/ui/cuicui/other/creative-effects/animated-noise/static-noise.tsx
+++ b/src/ui/cuicui/other/creative-effects/animated-noise/static-noise.tsx
@@ -1,0 +1,26 @@
+import { cn } from "#/src/utils/cn";
+import type { HTMLAttributes } from "react";
+
+export default function StaticNoise({
+  opacity,
+  className,
+  ...props
+}: { opacity: number } & HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "absolute bg-noise inset-0 z-40 pointer-events-none select-none",
+        className,
+      )}
+      style={{
+        backgroundRepeat: "repeat",
+        backgroundImage: svgUrlEncoded,
+        backgroundSize: "20%",
+        opacity,
+      }}
+      {...props}
+    />
+  );
+}
+
+const svgUrlEncoded = `url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' version='1.1' xmlnsXlink='http://www.w3.org/1999/xlink' viewBox='0 0 700 700' width='700' height='700' opacity='1'%3e%3ctitle%3enoise%3c/title%3e%3cdefs%3e%3cfilter id='nnnoise-filter' x='-20%25' y='-20%25' width='140%25' height='140%25' filterUnits='objectBoundingBox' primitiveUnits='userSpaceOnUse' color-interpolation-filters='linearRGB'%3e%3cfeTurbulence type='fractalNoise' baseFrequency='0.2' numOctaves='4' seed='15' stitchTiles='stitch' x='0%25' y='0%25' width='100%25' height='100%25' result='turbulence'/%3e%3cfeSpecularLighting surfaceScale='5' specularConstant='0.8' specularExponent='20' lighting-color='white' x='0%25' y='0%25' width='100%25' height='100%25' in='turbulence' result='specularLighting'%3e%3cfeDistantLight azimuth='3' elevation='96'/%3e%3c/feSpecularLighting%3e%3cfeColorMatrix type='saturate' values='0' x='0%25' y='0%25' width='100%25' height='100%25' in='specularLighting' result='colormatrix'/%3e%3c/filter%3e%3c/defs%3e%3crect width='700' height='700' fill='black'/%3e%3crect width='700' height='700' fill='white' filter='url(%23nnnoise-filter)'/%3e%3c/svg%3e")`;

--- a/src/ui/cuicui/other/creative-effects/border-trail/border-trail.tsx
+++ b/src/ui/cuicui/other/creative-effects/border-trail/border-trail.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { cn } from "#/src/utils/cn";
+import { motion, type Transition } from "framer-motion";
+import type { CSSProperties } from "react";
+
+type BorderTrailProps = {
+  className?: string;
+  size?: number;
+  transition?: Transition;
+  delay?: number;
+  onAnimationComplete?: () => void;
+  style?: CSSProperties;
+};
+
+export function BorderTrail({
+  className,
+  size = 60,
+  transition,
+  delay,
+  onAnimationComplete,
+  style,
+}: BorderTrailProps) {
+  const BASE_TRANSITION = {
+    repeat: Number.POSITIVE_INFINITY,
+    duration: 5,
+    ease: "linear",
+  };
+
+  return (
+    <div className="pointer-events-none absolute inset-0 rounded-[inherit] border border-transparent [mask-clip:padding-box,border-box] [mask-composite:intersect] [mask-image:linear-gradient(transparent,transparent),linear-gradient(#000,#000)]">
+      <motion.div
+        className={cn("absolute aspect-square bg-zinc-500", className)}
+        style={{
+          width: size,
+          offsetPath: `rect(0 auto auto 0 round ${size}px)`,
+          ...style,
+        }}
+        animate={{
+          offsetDistance: ["0%", "100%"],
+        }}
+        transition={{
+          ...(transition ?? BASE_TRANSITION),
+          delay: delay,
+        }}
+        onAnimationComplete={onAnimationComplete}
+      />
+    </div>
+  );
+}

--- a/src/ui/cuicui/other/creative-effects/border-trail/component.animated-noise.tsx
+++ b/src/ui/cuicui/other/creative-effects/border-trail/component.animated-noise.tsx
@@ -1,0 +1,19 @@
+import type { ComponentType } from "#/src/lib/types/component";
+import PreviewBorderTrail from "#/src/ui/cuicui/other/creative-effects/border-trail/preview.border-trail";
+
+export const borderTrailComponent: ComponentType = {
+  slug: "border-trail",
+  name: "Border Trail",
+  description:
+    "A border trail effect that can be used in any component with any modern style",
+  sizePreview: "lg",
+  variantList: [
+    {
+      name: "Border Trail",
+      slugPreviewFile: "preview.border-trail",
+      slugComponentFile: "border-trail",
+      component: <PreviewBorderTrail />,
+    },
+  ],
+  lastUpdatedDateComponent: new Date("2024-10-15"),
+};

--- a/src/ui/cuicui/other/creative-effects/border-trail/preview.border-trail.tsx
+++ b/src/ui/cuicui/other/creative-effects/border-trail/preview.border-trail.tsx
@@ -1,0 +1,25 @@
+import { BorderTrail } from "#/src/ui/cuicui/other/creative-effects/border-trail/border-trail";
+
+export default function PreviewBorderTrail() {
+  return (
+    <div className="relative flex h-[200px] w-[300px] flex-col items-center justify-center rounded-md bg-zinc-200 px-5 py-2 dark:bg-zinc-900">
+      <BorderTrail
+        style={{
+          boxShadow:
+            "0px 0px 60px 30px rgb(255 255 255 / 50%), 0 0 100px 60px rgb(0 0 0 / 50%), 0 0 140px 90px rgb(0 0 0 / 50%)",
+        }}
+        size={100}
+      />
+      <output
+        className="flex h-full animate-pulse flex-col items-start justify-center space-y-2"
+        aria-label="Loading..."
+      >
+        <div className="h-1 w-4 rounded-[4px] bg-zinc-600" />
+        <div className="h-1 w-10 rounded-[4px] bg-zinc-600" />
+        <div className="h-1 w-12 rounded-[4px] bg-zinc-600" />
+        <div className="h-1 w-12 rounded-[4px] bg-zinc-600" />
+        <div className="h-1 w-12 rounded-[4px] bg-zinc-600" />
+      </output>
+    </div>
+  );
+}

--- a/src/ui/cuicui/other/creative-effects/category.creative-effet.tsx
+++ b/src/ui/cuicui/other/creative-effects/category.creative-effet.tsx
@@ -2,6 +2,8 @@ import { CreativeCommonsIcon } from "lucide-react";
 import type { CategoryType } from "#/src/lib/types/component";
 import PreviewBottomBlurOut from "#/src/ui/cuicui/other/creative-effects/bottom-blur-out/preview.bottom-blur-out";
 import { bottomBlurOutComponent } from "#/src/ui/cuicui/other/creative-effects/bottom-blur-out/component.bottom-blur-out";
+import { animatedNoiseComponent } from "#/src/ui/cuicui/other/creative-effects/animated-noise/component.animated-noise";
+import { borderTrailComponent } from "#/src/ui/cuicui/other/creative-effects/border-trail/component.animated-noise";
 
 export const creativeEffectCategory: CategoryType = {
   slug: "creative-effects",
@@ -14,5 +16,9 @@ export const creativeEffectCategory: CategoryType = {
     component: <PreviewBottomBlurOut />,
     previewScale: 1,
   },
-  componentList: [bottomBlurOutComponent],
+  componentList: [
+    animatedNoiseComponent,
+    borderTrailComponent,
+    bottomBlurOutComponent,
+  ],
 };

--- a/src/ui/cuicui/other/patterns/grid-pattern/component.grid-pattern.tsx
+++ b/src/ui/cuicui/other/patterns/grid-pattern/component.grid-pattern.tsx
@@ -1,0 +1,21 @@
+import type { ComponentType } from "#/src/lib/types/component";
+import GridPattern from "#/src/ui/cuicui/other/patterns/grid-pattern/grid-pattern";
+
+export const gridPatternComponent: ComponentType = {
+  sizePreview: "sm",
+  slug: "grid-pattern",
+  isIframed: false,
+  isChildUsingHeightFull: true,
+  name: "Simple grid pattern",
+  description:
+    "Create a simple grid pattern without images, just with CSS and HTML for better performance, SEO and accessibility & also more micro-interactions",
+  variantList: [
+    {
+      name: "Default",
+      component: <GridPattern />,
+
+      slugPreviewFile: "grid-pattern",
+    },
+  ],
+  lastUpdatedDateComponent: new Date("2024-10-15"),
+};

--- a/src/ui/cuicui/other/patterns/grid-pattern/grid-pattern.tsx
+++ b/src/ui/cuicui/other/patterns/grid-pattern/grid-pattern.tsx
@@ -1,0 +1,5 @@
+export default function GridPattern() {
+  return (
+    <div className="absolute inset-0 bg-[linear-gradient(to_right,#4f4f4f2e_1px,transparent_1px),linear-gradient(to_bottom,#4f4f4f2e_1px,transparent_1px)] bg-[size:35px_34px] [mask-image:radial-gradient(ellipse_60%_50%_at_50%_0%,#000_70%,transparent_100%)]" />
+  );
+}

--- a/src/ui/cuicui/other/patterns/patterns.category.tsx
+++ b/src/ui/cuicui/other/patterns/patterns.category.tsx
@@ -2,6 +2,7 @@ import { GripIcon } from "lucide-react";
 import type { CategoryType } from "#/src/lib/types/component";
 import { DotsPatternPreview } from "#/src/ui/cuicui/other/patterns/dots-pattern/dots-pattern-preview";
 import MovingBandsPreview from "#/src/ui/cuicui/other/patterns/moving-bands/moving-bands-preview";
+import { gridPatternComponent } from "#/src/ui/cuicui/other/patterns/grid-pattern/component.grid-pattern";
 export const patternsCategory: CategoryType = {
   slug: "patterns",
   name: "Patterns",
@@ -34,6 +35,7 @@ export const patternsCategory: CategoryType = {
       inspirationLink: "https://magicui.design/docs/components/dot-pattern",
       lastUpdatedDateComponent: new Date("2024-08-10"),
     },
+    gridPatternComponent,
     {
       sizePreview: "sm",
       slug: "moving-bands",

--- a/src/ui/cuicui/tools/css-selectors/category.css-selectors.tsx
+++ b/src/ui/cuicui/tools/css-selectors/category.css-selectors.tsx
@@ -1,0 +1,12 @@
+import { TextSelectionIcon } from "lucide-react";
+import type { PageCategoryType } from "#/src/lib/types/component";
+import { CssSelectorsTool } from "#/src/ui/cuicui/tools/css-selectors/page.css-selectors";
+
+export const cssSelectorsCategory: PageCategoryType = {
+  name: "CSS Selectors",
+  slug: "css-selectors",
+  icon: TextSelectionIcon,
+  description:
+    "A visual guide to CSS selectors. Learn how to target HTML elements with CSS.",
+  component: <CssSelectorsTool />,
+};

--- a/src/ui/cuicui/tools/css-selectors/page.css-selectors.tsx
+++ b/src/ui/cuicui/tools/css-selectors/page.css-selectors.tsx
@@ -1,0 +1,9 @@
+export function CssSelectorsTool() {
+  return (
+    <iframe
+      className="w-full h-dvh rounded-2xl"
+      src="https://www.fffuel.co/css-selectors/"
+      title="CSS Selectors visual guide"
+    />
+  );
+}

--- a/src/ui/cuicui/tools/noise-creator/category.noise-generator.tsx
+++ b/src/ui/cuicui/tools/noise-creator/category.noise-generator.tsx
@@ -1,0 +1,12 @@
+import { AudioLinesIcon } from "lucide-react";
+import type { PageCategoryType } from "#/src/lib/types/component";
+import { NoiseGenerator } from "#/src/ui/cuicui/tools/noise-creator/page.noise-generator";
+
+export const noiseGeneratorCategory: PageCategoryType = {
+  name: "Noise Generator",
+  slug: "noise-generator",
+  icon: AudioLinesIcon,
+  description:
+    "Generate noise for your projects. You can use it as a background, texture, or any other creative effect.",
+  component: <NoiseGenerator />,
+};

--- a/src/ui/cuicui/tools/noise-creator/page.noise-generator.tsx
+++ b/src/ui/cuicui/tools/noise-creator/page.noise-generator.tsx
@@ -1,0 +1,9 @@
+export function NoiseGenerator() {
+  return (
+    <iframe
+      className="w-full h-dvh rounded-2xl"
+      src="https://www.fffuel.co/nnnoise/"
+      title="Noise generator"
+    />
+  );
+}

--- a/src/ui/cuicui/tools/section.tools.tsx
+++ b/src/ui/cuicui/tools/section.tools.tsx
@@ -3,6 +3,8 @@ import type { PageSectionType } from "#/src/lib/types/component";
 import { bezierCurveGeneratorCategory } from "#/src/ui/cuicui/tools/bezier-curve-generator/category.bezier-curve-generator";
 import { ColorConverterCategory } from "#/src/ui/cuicui/tools/color-converter/category.color-converter";
 import { FormBuilderCategory } from "#/src/ui/cuicui/tools/form-builder/category.form-builder";
+import { noiseGeneratorCategory } from "#/src/ui/cuicui/tools/noise-creator/category.noise-generator";
+import { cssSelectorsCategory } from "#/src/ui/cuicui/tools/css-selectors/category.css-selectors";
 
 export const toolsSection: PageSectionType = {
   type: "page",
@@ -14,6 +16,8 @@ export const toolsSection: PageSectionType = {
   pageList: [
     bezierCurveGeneratorCategory,
     ColorConverterCategory,
+    cssSelectorsCategory,
     FormBuilderCategory,
+    noiseGeneratorCategory,
   ],
 };


### PR DESCRIPTION
This pull request introduces new hooks and creative effects, as well as updates to existing components and categories. The most important changes include adding a new `useClickOutside` hook, creating new animated and static noise components, and introducing a border trail effect.

### New Hooks:
* Added `useClickOutsideCategory` to the hooks section (`src/ui/cuicui/hooks/hooks.section.tsx`, `src/ui/cuicui/hooks/use-click-outside/category.use-click-outside.tsx`) [[1]](diffhunk://#diff-8a8f7501fd82de425e4a8a4dca919ebd0b1989527d43322223e1c930af2d9140R33) [[2]](diffhunk://#diff-8a8f7501fd82de425e4a8a4dca919ebd0b1989527d43322223e1c930af2d9140R43) [[3]](diffhunk://#diff-04d891c17514fef3feb3868ca2fa2cd970c9bf2fda86f20c682662d49375c034R1-R29).
* Implemented the `useOnClickOutside` hook for detecting clicks outside a specified element (`src/ui/cuicui/hooks/use-click-outside/use-click-outside.ts`).

### Creative Effects:
* Introduced `AnimatedNoise` and `StaticNoise` components for creative noise effects (`src/ui/cuicui/other/creative-effects/animated-noise/animated-noise.tsx`, `src/ui/cuicui/other/creative-effects/animated-noise/component.animated-noise.tsx`, `src/ui/cuicui/other/creative-effects/animated-noise/preview.animated-noise.tsx`, `src/ui/cuicui/other/creative-effects/animated-noise/preview.static-noise.tsx`, `src/ui/cuicui/other/creative-effects/animated-noise/static-noise.tsx`) [[1]](diffhunk://#diff-4b4a6b59860672d4d950b232b1951fd8cf856707eb80b277e06f10cdf09cb837R1-R69) [[2]](diffhunk://#diff-6b7b6d326d406e0e348e79f982bc6a28ed5563dcfa60b88c4128db7354d14287R1-R26) [[3]](diffhunk://#diff-0ae04facf54738166c8d2f09121e36fb5c7de00ac4d8e5da73dff105ee73d996R1-R16) [[4]](diffhunk://#diff-b67770a6925b3c5558ddc7d69beb11adddc8d570e9bac3170fa87d5df5779a32R1-R16) [[5]](diffhunk://#diff-32ad7818ff95b107db391e60fd05f7e18e11bec51da7b33bdeb826585011bfc7R1-R26).
* Added `BorderTrail` component for creating a border trail effect (`src/ui/cuicui/other/creative-effects/border-trail/border-trail.tsx`, `src/ui/cuicui/other/creative-effects/border-trail/component.animated-noise.tsx`, `src/ui/cuicui/other/creative-effects/border-trail/preview.border-trail.tsx`) [[1]](diffhunk://#diff-0307a275345a0450a693f83987150b10a85db73954a2a751cadbc2706d8fb26dR1-R50) [[2]](diffhunk://#diff-96084b9bda18ef977f0f0c592871674a07c0201b9a34658414cc81ecc279009aR1-R19) [[3]](diffhunk://#diff-328d636bb5932b109c78bd10617d58256574e3eed9961874f532652b8bc45a6eR1-R25).

### Category Updates:
* Updated `creativeEffectCategory` to include new components (`src/ui/cuicui/other/creative-effects/category.creative-effet.tsx`) [[1]](diffhunk://#diff-6b347248bc1ae39fc9c10fafca84b1b89fdc43ba97e5e4711e0ed3b45632a485R5-R6) [[2]](diffhunk://#diff-6b347248bc1ae39fc9c10fafca84b1b89fdc43ba97e5e4711e0ed3b45632a485L17-R23).
* Added `gridPatternComponent` to the patterns category (`src/ui/cuicui/other/patterns/grid-pattern/component.grid-pattern.tsx`, `src/ui/cuicui/other/patterns/grid-pattern/grid-pattern.tsx`, `src/ui/cuicui/other/patterns/patterns.category.tsx`) [[1]](diffhunk://#diff-9e5980edfbc133ed10edc7d8d3bce202695ae5479684468468559d9e2e046dceR1-R21) [[2]](diffhunk://#diff-9c1e3c9cfa58f389d39f492d540bd16f8c1b2079e920a88b862409d9b9bd83e9R1-R5) [[3]](diffhunk://#diff-8df454f1f1fdbfedf2330f3c6cff2b587f217cf331e7c45ed4d7796d9b88e5b8R5) [[4]](diffhunk://#diff-8df454f1f1fdbfedf2330f3c6cff2b587f217cf331e7c45ed4d7796d9b88e5b8R38).

### Tools:
* Introduced `cssSelectorsCategory` with a visual guide to CSS selectors (`src/ui/cuicui/tools/css-selectors/category.css-selectors.tsx`, `src/ui/cuicui/tools/css-selectors/page.css-selectors.tsx`) [[1]](diffhunk://#diff-a77537599c3cef46e3d70989323dfc0124caf0228409152563f5688b08248b2bR1-R12) [[2]](diffhunk://#diff-a82471dea1916371a30dc688610eef72a47106d7c51c436d5a87da8a8ea5678cR1-R9).
* Added `noiseGeneratorCategory` for generating noise for creative projects (`src/ui/cuicui/tools/noise-creator/category.noise-generator.tsx`).