### PR TITLE
Replace Plausible analytics with Umami

### DIFF
--- a/apps/website/src/app/layout.tsx
+++ b/apps/website/src/app/layout.tsx
@@ -58,19 +58,11 @@ export default function RootLayout({
     <html className={font.className} lang="en" suppressHydrationWarning={true}>
       <head>
         {IS_PRODUCTION && (
-          <>
-            <Script
-              data-domain="cuicui.day"
-              defer={true}
-              id="plausible-main"
-              src={`${env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN}/js/script.hash.outbound-links.js`}
-            />
-            <Script id="plausible-inline">
-              {
-                "window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }"
-              }
-            </Script>
-          </>
+          <Script
+            defer={true}
+            src="https://umami.damien-schneider.pro/script.js"
+            data-website-id="1ad3dc22-6b89-43d2-b38b-95bb1ffbc95d"
+          />
         )}
       </head>
       <Providers>


### PR DESCRIPTION
## Description

This PR replaces the Plausible analytics service with Umami for website analytics tracking. The change simplifies the analytics setup by removing the dual-script Plausible configuration and replacing it with a single Umami script tag.

**Changes:**
- Removed Plausible analytics scripts (`script.hash.outbound-links.js` and inline initialization)
- Added Umami analytics script with website ID `1ad3dc22-6b89-43d2-b38b-95bb1ffbc95d`
- Umami script is hosted at `https://umami.damien-schneider.pro/script.js`

## Type of Change

- [x] Other (analytics provider migration)

## Checklist

- [x] I have read and followed the Contributing Guidelines
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Context

This migration from Plausible to Umami provides an alternative analytics solution. The Umami script is configured to automatically track page views and events on the production environment.